### PR TITLE
Add tests for cwl war error handling

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -119,4 +119,35 @@ describe('API endpoints', () => {
       ]
     });
   });
+
+  test('GET /api/cwl/war/:index returns 400 for invalid index', async () => {
+    const res = await request(app).get('/api/cwl/war/0');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Ungültiger Index' });
+  });
+
+  test('GET /api/cwl/war/:index returns 404 when index is too high', async () => {
+    const group = { rounds: [{ warTag: '#AAA' }] };
+    nock(base)
+      .get(`/v1/clans/${getClanTag()}/currentwar/leaguegroup`)
+      .reply(200, group);
+
+    const res = await request(app).get('/api/cwl/war/2');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Kriegstag nicht gefunden oder Clan-Tag falsch.' });
+  });
+
+  test('GET /api/cwl/war/:index returns 404 when war not found', async () => {
+    const group = { rounds: [{ warTag: '#AAA' }] };
+    nock(base)
+      .get(`/v1/clans/${getClanTag()}/currentwar/leaguegroup`)
+      .reply(200, group);
+    nock(base)
+      .get('/v1/clanwarleagues/wars/%23AAA')
+      .reply(404);
+
+    const res = await request(app).get('/api/cwl/war/1');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Kriegstag nicht gefunden oder Clan-Tag falsch.' });
+  });
 });


### PR DESCRIPTION
## Summary
- cover invalid CWL war index and 404 cases in server tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ed05b6c883228193f1b9fe0192ae