### PR TITLE
Add CI with Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -31,4 +31,8 @@ This project provides an Express.js server that queries the Clash of Clans API a
 - `__tests__/` – Jest tests.
 - `.env.example` – template for environment variables.
 
+## Continuous Integration
+
+The test suite is automatically executed in GitHub Actions on each push and pull request.
+
 


### PR DESCRIPTION
## Summary
- create GitHub Actions workflow to run tests with Node 18
- note in README that tests run automatically in CI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ed0851b083229bbca77a03b15c89