### PR TITLE
Add global 404 handler with test

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -119,4 +119,9 @@ describe('API endpoints', () => {
       ]
     });
   });
+
+  test('unknown route returns 404', async () => {
+    const res = await request(app).get('/unknown');
+    expect(res.status).toBe(404);
+  });
 });

--- a/server.js
+++ b/server.js
@@ -189,6 +189,11 @@ app.get("/api/cwl/missing", async (req, res) => {
   }
 });
 
+// Handle unknown routes with 404
+app.use((req, res) => {
+  res.status(404).json({ error: "Not Found" });
+});
+
 if (require.main === module) {
   app.listen(PORT, () => {
     console.log(`🚀 Server läuft unter http://localhost:${PORT}`);


### PR DESCRIPTION
## Summary
- handle unknown routes with 404 in server.js
- test that `/unknown` returns 404

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ed0c82508322882096ad8e5c70a2